### PR TITLE
Add Electron workshop starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-# ElectronWorkshop
+# Electron Workshop
+
+Dies ist ein Starter-Projekt für einen didaktischen Workshop zum Thema Electron.
+
+Die folgenden Dateien bilden eine minimale Electron-Anwendung im Ordner `starter/`.
+Sie enthält absichtlich Lücken, die im Rahmen des Workshops ausgefüllt werden
+sollen. In jedem Schritt sind TODO-Kommentare im Code hinterlegt, die auf die zu
+implementierenden Stellen hinweisen.
+
+## Struktur
+
+- `starter/package.json` – Enthält die Abhängigkeiten und Startskripte.
+- `starter/main.js` – Main-Prozess mit Fenstererstellung und IPC-Logik (mit TODOs).
+- `starter/preload.js` – Stellt ausgewählte API-Aufrufe für den Renderer bereit.
+- `starter/index.html` – Oberfläche mit Buttons für die Übungen.
+- `starter/renderer.js` – Verbindet die UI mit der Electron-API (mit TODOs).
+- `starter/about.html` – Einfaches „Über“-Fenster.
+
+## Übungen
+
+1. **Datei öffnen**
+   - Implementiere in `main.js` die Funktion zum Anzeigen eines Datei-Auswahldialogs
+     (Verwendung von `dialog.showOpenDialog`).
+   - Sende den eingelesenen Dateiinhalt per IPC an den Renderer und zeige ihn im
+     Textfeld an.
+
+2. **About-Fenster**
+   - Erweitere `main.js` um eine Funktion zum Öffnen eines zweiten
+     `BrowserWindow`, in dem `about.html` geladen wird.
+   - Verbinde den Button in `index.html` mit dieser Funktion über IPC.
+
+3. **System-Integration (Tray oder Notification)**
+   - Optional: Erzeuge ein Tray-Icon mit Kontextmenü oder sende eine Desktop-
+     Benachrichtigung. Die notwendigen Stellen sind im Code markiert.
+
+4. **Bonus: Packaging**
+   - Installiere `electron-forge` oder `electron-builder` und erstelle ein
+     Installationspaket. (Wird im Workshop nur kurz angerissen.)
+
+Zum Starten der Anwendung (nachdem die TODOs bearbeitet sind):
+
+```bash
+cd starter
+npm install
+npm start
+```
+

--- a/starter/about.html
+++ b/starter/about.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <title>About</title>
+</head>
+<body>
+  <h2>Über diese App</h2>
+  <p>Dies ist ein kleines Beispiel für den Electron Workshop.</p>
+</body>
+</html>

--- a/starter/index.html
+++ b/starter/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <title>Electron Workshop</title>
+</head>
+<body>
+  <h1>Electron Workshop</h1>
+  <button id="openFile">Datei öffnen…</button>
+  <button id="about">About…</button>
+  <br />
+  <textarea id="editor" style="width:100%; height:70vh;"></textarea>
+  <script src="renderer.js"></script>
+</body>
+</html>

--- a/starter/main.js
+++ b/starter/main.js
@@ -1,0 +1,49 @@
+const { app, BrowserWindow, ipcMain, dialog, Notification, Tray, Menu } = require('electron');
+const path = require('path');
+
+let tray = null; // wird für die optionale Tray-Übung verwendet
+
+function createMainWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
+
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(() => {
+  createMainWindow();
+
+  // TODO: Wenn gewünscht, hier ein Tray-Icon initialisieren und ein Kontextmenü definieren
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createMainWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+// TODO: IPC-Handler für 'dialog:openFile'
+ipcMain.handle('dialog:openFile', async () => {
+  // Hier soll ein Datei-Öffnen-Dialog angezeigt und der Dateiinhalt zurückgegeben werden
+});
+
+// TODO: IPC-Handler für 'window:openAbout'
+ipcMain.on('window:openAbout', () => {
+  // Erstelle ein zweites BrowserWindow und lade 'about.html'
+});
+
+// TODO: Beispiel für Notification (optional)
+function showNotification () {
+  new Notification({ title: 'Electron Workshop', body: 'Hello from the Main process!' }).show();
+}

--- a/starter/package.json
+++ b/starter/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "electron-workshop",
+  "version": "1.0.0",
+  "description": "Starter für einen didaktischen Electron-Workshop",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "^28.2.5"
+  }
+}

--- a/starter/preload.js
+++ b/starter/preload.js
@@ -1,0 +1,7 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('api', {
+  openFile: () => ipcRenderer.invoke('dialog:openFile'),
+  openAbout: () => ipcRenderer.send('window:openAbout'),
+  onFileContent: (callback) => ipcRenderer.on('file-content', (event, data) => callback(data))
+});

--- a/starter/renderer.js
+++ b/starter/renderer.js
@@ -1,0 +1,17 @@
+const openBtn = document.getElementById('openFile');
+const aboutBtn = document.getElementById('about');
+const editor = document.getElementById('editor');
+
+openBtn.addEventListener('click', () => {
+  // Ruft die im Preload bereitgestellte Funktion auf
+  window.api.openFile();
+});
+
+aboutBtn.addEventListener('click', () => {
+  window.api.openAbout();
+});
+
+// Reagiert auf den vom Main-Prozess gesendeten Dateiinhalt
+window.api.onFileContent((text) => {
+  editor.value = text;
+});


### PR DESCRIPTION
## Summary
- add README with workshop instructions and tasks
- add starter Electron app with TODOs for participants

## Testing
- `npm test` *(fails: missing script and network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68646118cb9083278b46b18dee49bb00